### PR TITLE
set client address property with new variable sensu_client_address, defaulting to ansible_fqdn

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ vagrant up
 Role Variables
 --------------
 
-````
+```yaml
 ---
 # defaults file for ansible-sensu
 email_notifications: 'notifications@{{ pri_domain_name }}'
@@ -242,7 +242,7 @@ sensu_server_services:
 smtp_domain_name: '{{ pri_domain_name }}'
 smtp_server: 'smtp.{{ pri_domain_name }}'
 smtp_server_port: 25
-````
+```
 
 Dependencies
 ------------
@@ -255,7 +255,7 @@ Example Playbook
 ----------------
 
 #### GitHub
-````
+```yaml
 ---
 - hosts: all
   become: true
@@ -268,9 +268,12 @@ Example Playbook
     - role: ansible-redis
     - role: ansible-sensu
   tasks:
-````
+```
+
+
 #### Galaxy
-````
+
+```yaml
 ---
 - hosts: all
   become: true
@@ -283,7 +286,7 @@ Example Playbook
     - role: mrlesmithjr.redis
     - role: mrlesmithjr.sensu
   tasks:
-````
+```
 
 License
 -------

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -26,6 +26,7 @@ sensu_client_debian_packages:
   - sensu
   - ruby2.0
   - ruby2.0-dev
+sensu_client_address: "{{ ansible_fqdn }}"
 sensu_client_services:
   - sensu-client
 sensu_config_dir: '{{ sensu_root_dir }}/conf.d'

--- a/templates/etc/sensu/conf.d/client.json.j2
+++ b/templates/etc/sensu/conf.d/client.json.j2
@@ -1,7 +1,7 @@
 {
   "client":{
     "name": "{{ ansible_hostname }}",
-    "address": "{{ sensu_host }}",
+    "address": "{{ sensu_client_address }}",
     "subscriptions": [
 {% if sensu_client_subs is defined %}
 {% for item in sensu_client_subs %}


### PR DESCRIPTION
Formerly the Sensu client was configured with its `address` property set to variable `sensu_host`.  The `address` property should be a string describing the address of the host being monitored - but `sensu_host` is the address of the Sensu server.  With the original playbook, Uchiwa looks like this:
![clients uchiwa - chromium_011](https://cloud.githubusercontent.com/assets/55682/15445835/ffe247ee-1ebd-11e6-892f-cad07ff36991.png)

With the changes in this PR, Uchiwa looks like this for the same hosts:
![clients uchiwa - chromium_012](https://cloud.githubusercontent.com/assets/55682/15445838/14fe055a-1ebe-11e6-87c0-13c5dcd9f51e.png)

This PR also adds YAML syntax highlighting to the README.
